### PR TITLE
Fixed npm install error (node-gyp) with update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/sweetpi/i2c-lcd.git"
   },
   "dependencies": {
-    "i2c": "~0.1.7",
+    "i2c": "~0.2.1",
     "bluebird": "~2.9.13"
   },
   "keywords": [


### PR DESCRIPTION
Attempts to npm install threw the following error:

gyp ERR! stack Error: 'make' failed with exit code: 2

Updated i2c package version from 0.1.7 to 0.2.1 fixed the problem, allowing for successful npm install

npm v 2.11.2 
node v 0.12.6
